### PR TITLE
feat: improve & clean up generate, diffing & migration flows

### DIFF
--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -3,9 +3,12 @@ import { GenerateMigrationOptions } from "../types";
 import { getDatabase } from "../utilities/get-database";
 import { generateMigrationPreview } from "../core/generate";
 import { generateSnapshotFromCodebase } from "../core/detection";
+import { generateDatabaseSnapshot } from "../core/snapshot";
+import { diffSnapshots } from "../core/diff";
+import { MigrationStore } from "../core/store";
 
 /**
- * Main generate command function
+ * Main generate command function - now works with on-demand snapshot generation
  */
 export default async function generate(
   options: GenerateMigrationOptions = {}
@@ -15,28 +18,18 @@ export default async function generate(
 
     // Load database connection
     const db = await getDatabase();
-
     console.log(chalk.green("✅ Database connection established"));
 
-    // Import store and snapshot utilities
-    const { MigrationStore } = await import("../core/store");
-    const { generateSnapshot } = await import("../core/snapshot");
-    const { diffSnapshots } = await import("../core/diff");
-
-    // Initialize the migration store
+    // Initialize the migration store (only for tracking applied migrations)
     const store = new MigrationStore(db);
-
     await store.initialize();
 
-    const { snapshot: currentSnapshot } = await generateSnapshotFromCodebase();
+    // Generate snapshots on-demand (no storage)
+    const { snapshot: codeSnapshot } = await generateSnapshotFromCodebase();
 
-    await store.storeSnapshot(currentSnapshot);
+    const databaseSnapshot = await generateDatabaseSnapshot(db, 1);
 
-    const latestSnapshot = await generateSnapshot(db, 1);
-
-    await store.storeSnapshot(latestSnapshot);
-
-    const diffResult = diffSnapshots(latestSnapshot, currentSnapshot);
+    const diffResult = diffSnapshots(databaseSnapshot, codeSnapshot);
 
     // Check if there are any changes
     const hasChanges = diffResult.up.length > 0 || diffResult.down.length > 0;
@@ -50,77 +43,69 @@ export default async function generate(
         )
       );
 
-      return;
+      return process.exit(0);
     }
 
     // Show detected changes summary
-    if (hasChanges) {
-      console.log(chalk.green(`✅ Detected changes:`));
+    console.log(chalk.green("✅ Detected changes:"));
 
-      const { metadata } = diffResult;
+    const { metadata } = diffResult;
 
-      if (metadata.collections.added.length > 0) {
-        console.log(
-          chalk.cyan(
-            `   • Collections added: ${metadata.collections.added.join(", ")}`
-          )
-        );
-      }
-
-      if (metadata.collections.removed.length > 0) {
-        console.log(
-          chalk.yellow(
-            `   • Collections removed: ${metadata.collections.removed.join(
-              ", "
-            )}`
-          )
-        );
-      }
-
-      if (metadata.collections.modified.length > 0) {
-        console.log(
-          chalk.cyan(
-            `   • Collections modified: ${metadata.collections.modified.join(
-              ", "
-            )}`
-          )
-        );
-      }
-
-      const totalFieldChanges =
-        metadata.fields.added.length +
-        metadata.fields.removed.length +
-        metadata.fields.modified.length +
-        metadata.fields.renamed.length;
-
-      if (totalFieldChanges > 0) {
-        console.log(chalk.cyan(`   • Field changes: ${totalFieldChanges}`));
-      }
-
-      const totalIndexChanges =
-        metadata.indexes.added.length + metadata.indexes.removed.length;
-
-      if (totalIndexChanges > 0) {
-        console.log(chalk.cyan(`   • Index changes: ${totalIndexChanges}`));
-      }
+    if (metadata.collections.added.length > 0) {
+      console.log(
+        chalk.cyan(
+          `   • Collections added: ${metadata.collections.added.join(", ")}`
+        )
+      );
     }
 
-    // Generate migration preview file
-    console.log(chalk.cyan("📝 Generating migration file..."));
+    if (metadata.collections.removed.length > 0) {
+      console.log(
+        chalk.yellow(
+          `   • Collections removed: ${metadata.collections.removed.join(", ")}`
+        )
+      );
+    }
 
+    if (metadata.collections.modified.length > 0) {
+      console.log(
+        chalk.cyan(
+          `   • Collections modified: ${metadata.collections.modified.join(
+            ", "
+          )}`
+        )
+      );
+    }
+
+    const totalFieldChanges =
+      metadata.fields.added.length +
+      metadata.fields.removed.length +
+      metadata.fields.modified.length +
+      metadata.fields.renamed.length;
+
+    if (totalFieldChanges > 0) {
+      console.log(chalk.cyan(`   • Field changes: ${totalFieldChanges}`));
+    }
+
+    const totalIndexChanges =
+      metadata.indexes.added.length + metadata.indexes.removed.length;
+
+    if (totalIndexChanges > 0) {
+      console.log(chalk.cyan(`   • Index changes: ${totalIndexChanges}`));
+    }
+
+    // Generate migration file
+    console.log(chalk.cyan("📝 Generating migration file..."));
     await generateMigrationPreview(diffResult, options);
 
     // Show next steps
-    console.log(chalk.cyan("\n📝 Next Steps:"));
-
+    console.log(chalk.cyan("\n📋 Next Steps:"));
     console.log(chalk.cyan("   1. Review the generated migration file"));
-
     console.log(
       chalk.cyan("   2. Edit if necessary (add custom logic, modify commands)")
     );
-
     console.log(
-      chalk.cyan(`   3. Run 'mongeese migrate up' to apply the migration`)
+      chalk.cyan("   3. Run 'mongeese migrate up' to apply the migration")
     );
 
     if (diffResult.warnings.length > 0) {
@@ -130,6 +115,7 @@ export default async function generate(
         )
       );
     }
+
     process.exit(0);
   } catch (error) {
     console.error(chalk.red("❌ Error generating migration:"), error);

--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -8,16 +8,18 @@ import {
   EnhancedCollectionStructure,
 } from "../types";
 
-/**
- * Normalize snapshot for deterministic serialization
- */
+// Fields that are automatically managed by Mongoose and should be ignored
+const MONGOOSE_MANAGED_FIELDS = new Set(["_id", "__v"]);
+
+// Fields that are commonly auto-generated and we shouldn't warn about type changes
+const AUTO_GENERATED_FIELDS = new Set(["_id", "__v", "createdAt", "updatedAt"]);
+
 export function normalizeSnapshot(snapshot: Snapshot): NormalizedSnapshot {
   const normalized: NormalizedSnapshot = {
     version: snapshot.version,
     collections: {},
   };
 
-  // Sort collections alphabetically
   const sortedCollectionNames = Object.keys(snapshot.collections).sort();
 
   for (const collectionName of sortedCollectionNames) {
@@ -27,13 +29,15 @@ export function normalizeSnapshot(snapshot: Snapshot): NormalizedSnapshot {
       indexes: [],
     };
 
-    // Sort fields alphabetically
-    const sortedFieldNames = Object.keys(collection.fields).sort();
+    // Filter out Mongoose-managed fields during normalization
+    const sortedFieldNames = Object.keys(collection.fields)
+      .filter(fieldName => !MONGOOSE_MANAGED_FIELDS.has(fieldName))
+      .sort();
+
     for (const fieldName of sortedFieldNames) {
       normalizedCollection.fields[fieldName] = collection.fields[fieldName];
     }
 
-    // Sort indexes by canonical representation
     if (collection.indexes) {
       normalizedCollection.indexes = collection.indexes
         .map(normalizeIndex)
@@ -46,9 +50,6 @@ export function normalizeSnapshot(snapshot: Snapshot): NormalizedSnapshot {
   return normalized;
 }
 
-/**
- * Normalize index definition for consistent comparison
- */
 function normalizeIndex(index: any): IndexDefinition {
   return {
     fields: Array.isArray(index.fields)
@@ -74,18 +75,19 @@ function normalizeIndex(index: any): IndexDefinition {
   };
 }
 
-/**
- * Get all field paths from a collection (including nested)
- */
 function getAllFieldPaths(fields: {
   [name: string]: FieldDefinition;
 }): string[] {
   const paths: string[] = [];
 
   for (const [fieldName, fieldDef] of Object.entries(fields)) {
+    // Skip Mongoose-managed fields
+    if (MONGOOSE_MANAGED_FIELDS.has(fieldName)) {
+      continue;
+    }
+
     paths.push(fieldName);
 
-    // Handle nested object fields
     if (fieldDef.type === "Object" && fieldDef.nestedFields) {
       for (const nestedPath of Object.keys(fieldDef.nestedFields)) {
         paths.push(`${fieldName}.${nestedPath}`);
@@ -96,146 +98,91 @@ function getAllFieldPaths(fields: {
   return paths.sort();
 }
 
-/**
- * Compare two field definitions
- */
 function compareFields(
   from: FieldDefinition,
-  to: FieldDefinition
+  to: FieldDefinition,
+  fieldName: string
 ): {
   changed: boolean;
   changes: string[];
+  significantChange: boolean; // Only changes that require migration
 } {
   const changes: string[] = [];
+  let significantChange = false;
 
-  if (from.type !== to.type) {
+  if (from.type !== "Mixed" && from.type !== to.type) {
     changes.push(`type: ${from.type} → ${to.type}`);
+    // Only consider it significant if it's a real type change, not Mixed → ActualType
+    // Also ignore type changes for auto-generated fields (they're usually correct in code)
+    if (to.type !== "Mixed" && !AUTO_GENERATED_FIELDS.has(fieldName)) {
+      significantChange = true;
+    }
   }
 
   if (from.nullable !== to.nullable) {
     changes.push(`nullable: ${from.nullable} → ${to.nullable}`);
+    // Nullable changes don't require data migration
   }
 
   if (from.required !== to.required) {
     changes.push(`required: ${from.required} → ${to.required}`);
+    // Required changes don't require data migration - Mongoose handles validation
   }
 
-  // Compare defaults (including function defaults)
   const fromDefault = JSON.stringify(from.default);
-
   const toDefault = JSON.stringify(to.default);
 
   if (fromDefault !== toDefault) {
     changes.push(`default: ${fromDefault} → ${toDefault}`);
+    // Default changes don't require data migration - only affect new documents
   }
 
-  // Compare enums
   const fromEnum = JSON.stringify(from.enum?.sort());
-
   const toEnum = JSON.stringify(to.enum?.sort());
 
   if (fromEnum !== toEnum) {
     changes.push(`enum: ${fromEnum} → ${toEnum}`);
+    // Enum changes don't require data migration - Mongoose handles validation
   }
 
-  return { changed: changes.length > 0, changes };
+  return {
+    changed: changes.length > 0,
+    changes,
+    significantChange,
+  };
 }
 
 /**
- * Detect field renames based on type and metadata similarity
+ * Enhanced field diffing with cleaner output and smarter filtering
  */
-function detectFieldRenames(
-  fromFields: { [name: string]: FieldDefinition },
-  toFields: { [name: string]: FieldDefinition }
-): Array<{ from: string; to: string; confidence: number }> {
-  const renames: Array<{ from: string; to: string; confidence: number }> = [];
-
-  const fromFieldNames = Object.keys(fromFields);
-
-  const toFieldNames = Object.keys(toFields);
-
-  for (const fromName of fromFieldNames) {
-    if (toFields[fromName]) continue; // Field still exists
-
-    const fromField = fromFields[fromName];
-
-    let bestMatch: { name: string; confidence: number } | null = null;
-
-    for (const toName of toFieldNames) {
-      if (fromFields[toName]) continue; // Field existed before
-
-      const toField = toFields[toName];
-
-      let confidence = 0;
-
-      // Type match
-      if (fromField.type === toField.type) confidence += 0.4;
-
-      // Nullable match
-      if (fromField.nullable === toField.nullable) confidence += 0.2;
-
-      // Required match
-      if (fromField.required === toField.required) confidence += 0.2;
-
-      // Default value match
-      if (JSON.stringify(fromField.default) === JSON.stringify(toField.default))
-        confidence += 0.1;
-
-      // Enum match
-      if (
-        JSON.stringify(fromField.enum?.sort()) ===
-        JSON.stringify(toField.enum?.sort())
-      )
-        confidence += 0.1;
-
-      if (
-        confidence > 0.7 &&
-        (!bestMatch || confidence > bestMatch.confidence)
-      ) {
-        bestMatch = { name: toName, confidence };
-      }
-    }
-
-    if (bestMatch) {
-      renames.push({
-        from: fromName,
-        to: bestMatch.name,
-        confidence: bestMatch.confidence,
-      });
-    }
-  }
-
-  return renames;
-}
-
-/**
- * Enhanced field diffing with code-first approach and smart default handling
- */
-function diffFieldsCodeFirst(
+function diffFieldsRefined(
   collectionName: string,
   dbFields: { [name: string]: FieldDefinition }, // Database snapshot (comparison only)
   codeFields: { [name: string]: FieldDefinition } // Code snapshot (source of truth)
 ): { up: MigrationCommand[]; down: MigrationCommand[]; warnings: string[] } {
   const up: MigrationCommand[] = [];
-
   const down: MigrationCommand[] = [];
-
   const warnings: string[] = [];
 
-  const dbFieldNames = new Set(Object.keys(dbFields));
-
-  const codeFieldNames = new Set(Object.keys(codeFields));
-
-  console.log(
-    `[Mongeese] 🔍 Diffing fields for collection '${collectionName}'`
+  // Filter out Mongoose-managed fields from both snapshots
+  const filteredDbFields = Object.fromEntries(
+    Object.entries(dbFields).filter(
+      ([fieldName]) => !MONGOOSE_MANAGED_FIELDS.has(fieldName)
+    )
   );
-  console.log(`   📊 Database has ${dbFieldNames.size} fields`);
-  console.log(`   💻 Code defines ${codeFieldNames.size} fields`);
+  const filteredCodeFields = Object.fromEntries(
+    Object.entries(codeFields).filter(
+      ([fieldName]) => !MONGOOSE_MANAGED_FIELDS.has(fieldName)
+    )
+  );
+
+  const dbFieldNames = new Set(Object.keys(filteredDbFields));
+  const codeFieldNames = new Set(Object.keys(filteredCodeFields));
 
   // NEW FIELDS: In code but not in database
   for (const fieldName of codeFieldNames) {
     if (!dbFieldNames.has(fieldName)) {
-      const codeField = codeFields[fieldName];
+      const codeField = filteredCodeFields[fieldName];
 
       console.log(
         `   ➕ New field detected: '${fieldName}' (${codeField.type})`
@@ -243,16 +190,14 @@ function diffFieldsCodeFirst(
 
       // Smart default value handling
       let migrationValue: any = null;
+
       let description = `Add field '${fieldName}' to collection '${collectionName}'`;
 
       if (codeField.default !== undefined) {
         // Use the default value from code definition
         migrationValue = codeField.default;
-        description += ` with default value`;
 
-        console.log(
-          `     🎯 Using code default: ${JSON.stringify(migrationValue)}`
-        );
+        description += ` with default value`;
       } else if (!codeField.nullable && codeField.required) {
         // Field is required and non-nullable but has no default
         // We need to provide a sensible default based on type
@@ -279,11 +224,6 @@ function diffFieldsCodeFirst(
             migrationValue = null;
         }
 
-        console.log(
-          `     ⚡ Generated default for required field: ${JSON.stringify(
-            migrationValue
-          )}`
-        );
         description += ` with generated default (required field)`;
 
         warnings.push(
@@ -294,7 +234,6 @@ function diffFieldsCodeFirst(
       } else {
         // Field is optional or nullable, use null
         migrationValue = null;
-        console.log(`     ✅ Optional field, using null default`);
       }
 
       up.push({
@@ -320,12 +259,12 @@ function diffFieldsCodeFirst(
     }
   }
 
-  // REMOVED FIELDS: In database but not in code
+  // REMOVED FIELDS: In database but not in code (excluding Mongoose managed fields)
   for (const fieldName of dbFieldNames) {
     if (!codeFieldNames.has(fieldName)) {
       console.log(`   ➖ Removed field detected: '${fieldName}'`);
 
-      const dbField = dbFields[fieldName];
+      const dbField = filteredDbFields[fieldName];
 
       up.push({
         command: `db.collection("${collectionName}").updateMany({}, { $unset: { "${fieldName}": "" } })`,
@@ -352,113 +291,92 @@ function diffFieldsCodeFirst(
   }
 
   // MODIFIED FIELDS: Exist in both but may have different characteristics
-  // NOTE: For modified fields, we trust the code definition completely
-  // We only generate migrations for structural changes that affect the database
+  // Only generate migrations for truly significant changes
   for (const fieldName of codeFieldNames) {
     if (dbFieldNames.has(fieldName)) {
-      const codeField = codeFields[fieldName];
-      const dbField = dbFields[fieldName];
+      const codeField = filteredCodeFields[fieldName];
+      const dbField = filteredDbFields[fieldName];
 
-      const comparison = compareFields(dbField, codeField);
+      const comparison = compareFields(dbField, codeField, fieldName);
 
       if (comparison.changed) {
-        console.log(
-          `   🔄 Modified field: '${fieldName}' - ${comparison.changes.join(
-            ", "
-          )}`
-        );
-
-        // For most field property changes (type, nullable, required, enum),
-        // we don't need to modify existing data - Mongoose will handle validation
-        // Only generate migrations for changes that require data transformation
-
-        const hasTypeChange = comparison.changes.some(change =>
-          change.startsWith("type:")
-        );
-        const hasDefaultChange = comparison.changes.some(change =>
-          change.startsWith("default:")
-        );
-
-        if (hasTypeChange) {
+        // Only generate migrations for significant changes that actually require data transformation
+        if (comparison.significantChange) {
           warnings.push(
-            `⚠️  Type change for '${fieldName}' in '${collectionName}': ${dbField.type} → ${codeField.type}. Existing data may need manual migration.`
+            `⚠️  Significant type change for '${fieldName}' in '${collectionName}': ${dbField.type} → ${codeField.type}. Review if data migration is needed.`
           );
 
           up.push({
-            command: `// TODO: Migrate data for type change: ${fieldName} (${dbField.type} → ${codeField.type})`,
-            description: `Field '${fieldName}' type changed - may require data migration`,
+            command: `// TODO: Review type change for '${fieldName}': ${dbField.type} → ${codeField.type}`,
+            description: `Field '${fieldName}' type changed significantly - review data compatibility`,
             safetyLevel: "warning",
             metadata: {
               fieldPath: fieldName,
               changes: comparison.changes,
               fromField: dbField,
               toField: codeField,
-              reason: "type_change",
+              reason: "significant_type_change",
             },
           });
 
           down.push({
-            command: `// TODO: Revert data migration for: ${fieldName} (${codeField.type} → ${dbField.type})`,
-            description: `Revert type change for field '${fieldName}'`,
+            command: `// TODO: Revert type change for '${fieldName}': ${codeField.type} → ${dbField.type}`,
+            description: `Revert significant type change for field '${fieldName}'`,
             safetyLevel: "warning",
             metadata: {
               fieldPath: fieldName,
               fieldDefinition: dbField,
-              reason: "revert_type_change",
+              reason: "revert_significant_change",
             },
           });
         } else {
-          // For non-type changes, just log that the schema definition changed
-          up.push({
-            command: `// Schema updated: ${fieldName} - ${comparison.changes.join(
-              ", "
-            )}`,
-            description: `Field '${fieldName}' definition updated in code`,
-            safetyLevel: "safe",
-            metadata: {
-              fieldPath: fieldName,
-              changes: comparison.changes,
-              fromField: dbField,
-              toField: codeField,
-              reason: "schema_definition_change",
-            },
-          });
-
-          down.push({
-            command: `// Schema reverted: ${fieldName}`,
-            description: `Revert field '${fieldName}' definition`,
-            safetyLevel: "safe",
-            metadata: {
-              fieldPath: fieldName,
-              fieldDefinition: dbField,
-              reason: "revert_schema_change",
-            },
-          });
+          // For non-significant changes, just log them (no migration needed)
+          // const isAutoGenerated = AUTO_GENERATED_FIELDS.has(fieldName);
+          // if (!isAutoGenerated) {
+          //   console.log(
+          //     `     ℹ️  Non-significant change - Mongoose will handle validation`
+          //   );
+          // } else {
+          //   console.log(
+          //     `     ℹ️  Auto-generated field type normalized - no action needed`
+          //   );
+          // }
+          // up.push({
+          //   command: `// Schema definition updated: ${fieldName} (${comparison.changes.join(
+          //     ", "
+          //   )})`,
+          //   description: `Field '${fieldName}' schema updated${
+          //     isAutoGenerated ? " (auto-generated field)" : ""
+          //   } - no data migration needed`,
+          //   safetyLevel: "safe",
+          //   metadata: {
+          //     fieldPath: fieldName,
+          //     changes: comparison.changes,
+          //     fromField: dbField,
+          //     toField: codeField,
+          //     reason: isAutoGenerated
+          //       ? "auto_generated_field_normalized"
+          //       : "schema_definition_only",
+          //   },
+          // });
         }
       }
     }
   }
 
-  console.log(`   ✅ Field diff completed: ${up.length} migrations generated`);
-
   return { up, down, warnings };
 }
 
-/**
- * Diff collections (add/remove collections)
- */
+// Keep existing collection diffing but remove validator concerns
 function diffCollections(
   fromCollections: { [name: string]: EnhancedCollectionStructure },
   toCollections: { [name: string]: EnhancedCollectionStructure }
 ): { up: MigrationCommand[]; down: MigrationCommand[]; warnings: string[] } {
   const up: MigrationCommand[] = [];
-
   const down: MigrationCommand[] = [];
-
   const warnings: string[] = [];
 
   const fromNames = Object.keys(fromCollections);
-
   const toNames = Object.keys(toCollections);
 
   // Added collections
@@ -498,7 +416,7 @@ function diffCollections(
       });
 
       warnings.push(
-        `⚠️  Will drop collection '${collectionName}' - ensure it's empty or use --force`
+        `⚠️  Will drop collection '${collectionName}' - ensure it's backed up`
       );
     }
   }
@@ -506,205 +424,80 @@ function diffCollections(
   return { up, down, warnings };
 }
 
-/**
- * Diff fields within a collection
- */
-function diffFields(
+// Simplified index diffing (keep existing logic but make it cleaner)
+function diffIndexes(
   collectionName: string,
-  fromFields: { [name: string]: FieldDefinition },
-  toFields: { [name: string]: FieldDefinition }
+  fromIndexes: IndexDefinition[],
+  toIndexes: IndexDefinition[]
 ): { up: MigrationCommand[]; down: MigrationCommand[]; warnings: string[] } {
   const up: MigrationCommand[] = [];
-
   const down: MigrationCommand[] = [];
-
   const warnings: string[] = [];
 
-  const fromPaths = getAllFieldPaths(fromFields);
-
-  const toPaths = getAllFieldPaths(toFields);
-
-  // Detect renames first
-  const renames = detectFieldRenames(fromFields, toFields);
-
-  const renamedFrom = new Set(renames.map(r => r.from));
-
-  const renamedTo = new Set(renames.map(r => r.to));
-
-  // Added fields
-  for (const fieldPath of toPaths) {
-    // If it wasn't in the old snapshot and it wasn't renamed
-    if (!fromPaths.includes(fieldPath) && !renamedTo.has(fieldPath)) {
-      // Find the field definition by traversing the path
-      const pathParts = fieldPath.split(".");
-
-      let currentField: FieldDefinition | undefined = toFields[pathParts[0]];
-
-      // Handle nested fields
-      for (let i = 1; i < pathParts.length && currentField; i++) {
-        currentField = currentField.nestedFields?.[pathParts[i]];
-      }
-
-      if (!currentField) continue; // Skip if field definition not found
-
-      const fieldDef = currentField;
-
-      const defaultValue =
-        fieldDef.default !== undefined
-          ? JSON.stringify(fieldDef.default)
-          : "null";
-
-      up.push({
-        command: `db.collection("${collectionName}").updateMany({}, { $set: { "${fieldPath}": ${defaultValue} } })`,
-        description: `Add field '${fieldPath}' to collection '${collectionName}'`,
-        safetyLevel: "safe",
-        metadata: { fieldPath, fieldDefinition: fieldDef as FieldDefinition },
-      });
-
-      down.push({
-        command: `db.collection("${collectionName}").updateMany({}, { $unset: { "${fieldPath}": "" } })`,
-        description: `Remove field '${fieldPath}' from collection '${collectionName}'`,
-        safetyLevel: "warning",
-        metadata: { fieldPath },
-      });
-    }
+  // Compare indexes by their normalized structure
+  function indexSignature(index: IndexDefinition): string {
+    const normalized = normalizeIndex(index);
+    return JSON.stringify(normalized);
   }
 
-  // Removed fields
-  for (const fieldPath of fromPaths) {
-    if (!toPaths.includes(fieldPath) && !renamedFrom.has(fieldPath)) {
-      const fieldDef = fromFields[fieldPath];
+  const fromSignatures = fromIndexes.map(indexSignature);
+  const toSignatures = toIndexes.map(indexSignature);
+
+  // Added indexes
+  toIndexes.forEach((toIndex, i) => {
+    if (!fromSignatures.includes(toSignatures[i])) {
+      const fields = toIndex.fields
+        .map(f => `${f.field}: ${f.direction}`)
+        .join(", ");
 
       up.push({
-        command: `db.collection("${collectionName}").updateMany({}, { $unset: { "${fieldPath}": "" } })`,
-        description: `Remove field '${fieldPath}' from collection '${collectionName}'`,
+        command: generateIndexCommand(collectionName, toIndex),
+        description: `Create index on ${fields} for collection '${collectionName}'`,
+        safetyLevel: "safe",
+        metadata: { index: toIndex },
+      });
+
+      const indexName =
+        toIndex.name || toIndex.fields.map(f => f.field).join("_");
+
+      down.push({
+        command: `db.collection("${collectionName}").dropIndex("${indexName}")`,
+        description: `Drop index '${indexName}' from collection '${collectionName}'`,
         safetyLevel: "warning",
-        metadata: { fieldPath },
+        metadata: { indexName, index: toIndex },
+      });
+    }
+  });
+
+  // Removed indexes
+  fromIndexes.forEach((fromIndex, i) => {
+    if (!toSignatures.includes(fromSignatures[i])) {
+      const indexName =
+        fromIndex.name || fromIndex.fields.map(f => f.field).join("_");
+
+      up.push({
+        command: `db.collection("${collectionName}").dropIndex("${indexName}")`,
+        description: `Drop index '${indexName}' from collection '${collectionName}'`,
+        safetyLevel: "warning",
+        metadata: { indexName, index: fromIndex },
       });
 
       down.push({
-        command: `db.collection("${collectionName}").updateMany({}, { $set: { "${fieldPath}": ${JSON.stringify(
-          fieldDef.default || null
-        )} } })`,
-        description: `Restore field '${fieldPath}' to collection '${collectionName}'`,
+        command: generateIndexCommand(collectionName, fromIndex),
+        description: `Recreate index '${indexName}' on collection '${collectionName}'`,
         safetyLevel: "safe",
-        metadata: { fieldPath, fieldDefinition: fieldDef },
+        metadata: { index: fromIndex },
       });
 
       warnings.push(
-        `⚠️  Will remove field '${fieldPath}' from '${collectionName}'`
+        `⚠️  Will drop index '${indexName}' from '${collectionName}'`
       );
     }
-  }
-
-  // Renamed fields
-  for (const rename of renames) {
-    up.push({
-      command: `db.collection("${collectionName}").updateMany({}, { $rename: { "${rename.from}": "${rename.to}" } })`,
-      description: `Rename field '${rename.from}' to '${rename.to}' in collection '${collectionName}'`,
-      safetyLevel: "safe",
-      metadata: {
-        from: rename.from,
-        to: rename.to,
-        confidence: rename.confidence,
-      },
-    });
-
-    down.push({
-      command: `db.collection("${collectionName}").updateMany({}, { $rename: { "${rename.to}": "${rename.from}" } })`,
-      description: `Rename field '${rename.to}' back to '${rename.from}' in collection '${collectionName}'`,
-      safetyLevel: "safe",
-      metadata: { from: rename.to, to: rename.from },
-    });
-  }
-
-  // Modified fields
-  for (const fieldPath of fromPaths) {
-    if (toPaths.includes(fieldPath) && !renamedFrom.has(fieldPath)) {
-      // Find field definitions by traversing the path
-      const pathParts = fieldPath.split(".");
-
-      let fromField = fromFields[pathParts[0]];
-
-      let toField = toFields[pathParts[0]];
-
-      // Handle nested fields
-      for (let i = 1; i < pathParts.length; i++) {
-        if (fromField?.nestedFields?.[pathParts[i]]) {
-          fromField = fromField?.nestedFields?.[pathParts[i]];
-        }
-
-        if (toField?.nestedFields?.[pathParts[i]]) {
-          toField = toField?.nestedFields?.[pathParts[i]];
-        }
-      }
-
-      if (!fromField || !toField) continue; // Skip if either field not found
-
-      const comparison = compareFields(
-        fromField as FieldDefinition,
-        toField as FieldDefinition
-      );
-
-      if (comparison.changed) {
-        // For field modifications, we need to handle type changes carefully
-        if (
-          (fromField as FieldDefinition).type !==
-          (toField as FieldDefinition).type
-        ) {
-          warnings.push(
-            `⚠️  Type change for '${fieldPath}' in '${collectionName}': ${
-              (fromField as FieldDefinition).type
-            } → ${
-              (toField as FieldDefinition).type
-            } - may require data migration`
-          );
-        }
-
-        up.push({
-          command: `// Field '${fieldPath}' modified: ${comparison.changes.join(
-            ", "
-          )}`,
-          description: `Modify field '${fieldPath}' in collection '${collectionName}'`,
-          safetyLevel: "warning",
-          metadata: {
-            fieldPath,
-            changes: comparison.changes,
-            fromField: fromField as FieldDefinition,
-            toField: toField as FieldDefinition,
-          },
-        });
-
-        down.push({
-          command: `// Restore field '${fieldPath}' to previous state`,
-          description: `Restore field '${fieldPath}' in collection '${collectionName}'`,
-          safetyLevel: "warning",
-          metadata: {
-            fieldPath,
-            fieldDefinition: fromField as FieldDefinition,
-          },
-        });
-      }
-    }
-  }
+  });
 
   return { up, down, warnings };
 }
 
-/**
- * Compare two index definitions
- */
-function compareIndexes(from: IndexDefinition, to: IndexDefinition): boolean {
-  const fromStr = JSON.stringify(normalizeIndex(from));
-
-  const toStr = JSON.stringify(normalizeIndex(to));
-
-  return fromStr === toStr;
-}
-
-/**
- * Generate index creation command
- */
 function generateIndexCommand(
   collectionName: string,
   index: IndexDefinition
@@ -715,14 +508,8 @@ function generateIndexCommand(
 
   const options: string[] = [];
 
-  if (index.unique) {
-    options.push("unique: true");
-  }
-
-  if (index.sparse) {
-    options.push("sparse: true");
-  }
-
+  if (index.unique) options.push("unique: true");
+  if (index.sparse) options.push("sparse: true");
   if (index.partialFilterExpression) {
     options.push(
       `partialFilterExpression: ${JSON.stringify(
@@ -730,269 +517,174 @@ function generateIndexCommand(
       )}`
     );
   }
-
   if (index.expireAfterSeconds !== undefined) {
     options.push(`expireAfterSeconds: ${index.expireAfterSeconds}`);
   }
-
-  if (index.collation) {
-    options.push(`collation: ${JSON.stringify(index.collation)}`);
-  }
-
-  if (index.text) {
-    options.push("text: true");
-  }
-
-  if (index.geoHaystack) {
-    options.push("geoHaystack: true");
-  }
-
-  if (index.bucketSize) {
-    options.push(`bucketSize: ${index.bucketSize}`);
-  }
-
-  if (index.min !== undefined) {
-    options.push(`min: ${index.min}`);
-  }
-
-  if (index.max !== undefined) {
-    options.push(`max: ${index.max}`);
-  }
-
-  if (index.bits) {
-    options.push(`bits: ${index.bits}`);
-  }
-
-  if (index.name) {
-    options.push(`name: "${index.name}"`);
-  }
+  if (index.name) options.push(`name: "${index.name}"`);
 
   const optionsStr = options.length > 0 ? `, { ${options.join(", ")} }` : "";
 
   return `db.collection("${collectionName}").createIndex({ ${fields} }${optionsStr})`;
 }
 
-/**
- * Diff indexes within a collection
- */
-function diffIndexes(
-  collectionName: string,
-  fromIndexes: IndexDefinition[],
-  toIndexes: IndexDefinition[]
-): { up: MigrationCommand[]; down: MigrationCommand[]; warnings: string[] } {
-  const up: MigrationCommand[] = [];
-
-  const down: MigrationCommand[] = [];
-
-  const warnings: string[] = [];
-
-  // Added indexes
-  for (const toIndex of toIndexes) {
-    const indexExists = fromIndexes.some(fromIndex =>
-      compareIndexes(fromIndex, toIndex)
-    );
-
-    if (!indexExists) {
-      up.push({
-        command: generateIndexCommand(collectionName, toIndex),
-        description: `Create index on collection '${collectionName}'`,
-        safetyLevel: "safe",
-        metadata: { index: toIndex },
-      });
-
-      const indexName =
-        toIndex.name || toIndex.fields.map(f => f.field).join("_");
-
-      down.push({
-        command: `db.collection("${collectionName}").dropIndex("${indexName}")`,
-        description: `Drop index from collection '${collectionName}'`,
-        safetyLevel: "warning",
-        metadata: { indexName, index: toIndex },
-      });
-    }
-  }
-
-  // Removed indexes
-  for (const fromIndex of fromIndexes) {
-    const indexExists = toIndexes.some(toIndex =>
-      compareIndexes(fromIndex, toIndex)
-    );
-
-    if (!indexExists) {
-      const indexName =
-        fromIndex.name || fromIndex.fields.map(f => f.field).join("_");
-
-      up.push({
-        command: `db.collection("${collectionName}").dropIndex("${indexName}")`,
-        description: `Drop index from collection '${collectionName}'`,
-        safetyLevel: "warning",
-        metadata: { indexName, index: fromIndex },
-      });
-
-      down.push({
-        command: generateIndexCommand(collectionName, fromIndex),
-        description: `Recreate index on collection '${collectionName}'`,
-        safetyLevel: "safe",
-        metadata: { index: fromIndex },
-      });
-
-      warnings.push(
-        `⚠️  Will drop index '${indexName}' from '${collectionName}'`
-      );
-    }
-  }
-
-  return { up, down, warnings };
-}
-
-/**
- * Diff validators within a collection
- */
-function diffValidators(
-  collectionName: string,
-  fromValidator: any,
-  toValidator: any
-): { up: MigrationCommand[]; down: MigrationCommand[]; warnings: string[] } {
-  const up: MigrationCommand[] = [];
-
-  const down: MigrationCommand[] = [];
-
-  const warnings: string[] = [];
-
-  const fromStr = JSON.stringify(fromValidator);
-
-  const toStr = JSON.stringify(toValidator);
-
-  if (fromStr !== toStr) {
-    if (toValidator) {
-      up.push({
-        command: `db.runCommand({ collMod: "${collectionName}", validator: ${JSON.stringify(
-          toValidator
-        )} })`,
-        description: `Update validator for collection '${collectionName}'`,
-        safetyLevel: "warning",
-        metadata: { validator: toValidator },
-      });
-    } else {
-      up.push({
-        command: `db.runCommand({ collMod: "${collectionName}", validator: {} })`,
-        description: `Remove validator from collection '${collectionName}'`,
-        safetyLevel: "warning",
-        metadata: {},
-      });
-    }
-
-    if (fromValidator) {
-      down.push({
-        command: `db.runCommand({ collMod: "${collectionName}", validator: ${JSON.stringify(
-          fromValidator
-        )} })`,
-        description: `Restore validator for collection '${collectionName}'`,
-        safetyLevel: "warning",
-        metadata: { validator: fromValidator },
-      });
-    } else {
-      down.push({
-        command: `db.runCommand({ collMod: "${collectionName}", validator: {} })`,
-        description: `Remove validator from collection '${collectionName}'`,
-        safetyLevel: "warning",
-        metadata: {},
-      });
-    }
-
-    warnings.push(
-      `⚠️  Will modify validator for collection '${collectionName}'`
-    );
-  }
-
-  return { up, down, warnings };
-}
-
-/**
- * Inject session into MongoDB command for transaction support
- */
 function injectSessionIntoCommand(command: string): string {
-  // Skip comments
   if (command.trim().startsWith("//")) {
     return command;
   }
 
-  // Handle db.collection(...).method(...) pattern
+  // Handle different MongoDB operations with proper session injection
   if (command.includes("db.collection(")) {
-    // Find the last closing parenthesis and inject session before it
-    const lastParenIndex = command.lastIndexOf(")");
+    // Extract collection name and method
+    const collectionMatch = command.match(
+      /db\.collection\("([^"]+)"\)\.(\w+)\(/
+    );
 
-    if (lastParenIndex > -1) {
-      // Check if there are already options
-      const beforeLastParen = command.substring(0, lastParenIndex);
+    if (!collectionMatch) {
+      return command;
+    }
 
-      const afterLastParen = command.substring(lastParenIndex);
+    const [, _, method] = collectionMatch;
 
-      // Look for existing options object
-      const optionsStart = beforeLastParen.lastIndexOf("{");
+    switch (method) {
+      case "drop": {
+        // Drop operations cannot run in transactions and are irreversible
+        // Require manual execution to prevent accidental data loss
+        return command.replace(
+          /db\.collection\("([^"]+)"\)\.drop\(\)/,
+          `// WARNING: Execute manually outside or delete from your MongoDB Database: db.collection("$1").drop()
+           // This operation is irreversible and cannot run within a transaction`
+        );
+      }
 
-      const commaBeforeOptions = beforeLastParen.lastIndexOf(",");
+      case "createIndex": {
+        // No need for this call because Mongoose does this under the hood already
 
-      if (optionsStart > commaBeforeOptions) {
-        // There's already an options object, add session to it
-        return beforeLastParen + ", session" + afterLastParen;
-      } else {
-        // No options object, create one with session
-        return beforeLastParen + ", { session }" + afterLastParen;
+        // // Index creation: add session to options object or create one
+        // const lastParenIndex = command.lastIndexOf(")");
+        // if (lastParenIndex > -1) {
+        //   const beforeLastParen = command.substring(0, lastParenIndex);
+        //   const afterLastParen = command.substring(lastParenIndex);
+
+        //   // Check if there's already an options object
+        //   const optionsMatch = beforeLastParen.match(/,\s*\{([^}]*)\}\s*$/);
+        //   if (optionsMatch) {
+        //     // Add session to existing options
+        //     return beforeLastParen.replace(
+        //       /,\s*\{([^}]*)\}\s*$/,
+        //       ', { $1, session }'
+        //     ) + afterLastParen;
+        //   } else {
+        //     // Add session as new options object
+        //     return beforeLastParen + ', { session }' + afterLastParen;
+        //   }
+        // }
+        break;
+      }
+
+      case "dropIndex": {
+        // dropIndex cannot run in transactions - require manual execution
+        return command.replace(
+          /db\.collection\("([^"]+)"\)\.dropIndex\("([^"]+)"\)/,
+          '// WARNING: Execute manually outside or delete from your MongoDB Database: db.collection("$1").dropIndex("$2")\n// Index drops cannot run within a transaction'
+        );
+      }
+
+      case "updateMany":
+      case "updateOne":
+      case "deleteMany":
+      case "deleteOne":
+      case "replaceOne":
+      case "findOneAndUpdate":
+      case "findOneAndReplace":
+      case "findOneAndDelete": {
+        // Update operations: session should be in options (third parameter)
+        const updateMatch = command.match(
+          /^(.+\.(?:updateMany|updateOne|deleteMany|deleteOne|replaceOne|findOneAndUpdate|findOneAndReplace|findOneAndDelete)\([^,]+,\s*[^,]+)(\s*\))(.*)$/
+        );
+
+        if (updateMatch) {
+          const [, beforeOptions, closeParen, after] = updateMatch;
+
+          return `${beforeOptions}, { session }${closeParen}${after}`;
+        }
+
+        break;
+      }
+
+      case "insertOne":
+      case "insertMany": {
+        // Insert operations: session goes in options (second parameter)
+        const insertMatch = command.match(
+          /^(.+\.(?:insertOne|insertMany)\([^)]+)(\))(.*)$/
+        );
+
+        if (insertMatch) {
+          const [, beforeClose, closeParen, after] = insertMatch;
+          return `${beforeClose}, { session }${closeParen}${after}`;
+        }
+
+        break;
       }
     }
   }
 
-  // Handle db.runCommand(...) pattern
-  if (command.includes("db.runCommand(")) {
-    const lastParenIndex = command.lastIndexOf(")");
-    if (lastParenIndex > -1) {
-      return (
-        command.substring(0, lastParenIndex) +
-        ", { session }" +
-        command.substring(lastParenIndex)
-      );
+  // Handle db.createCollection separately
+  if (command.includes("db.createCollection(")) {
+    const createMatch = command.match(
+      /^(.+db\.createCollection\("[^"]+")(\))(.*)$/
+    );
+
+    if (createMatch) {
+      const [, beforeClose, closeParen, after] = createMatch;
+
+      return `${beforeClose}, { session }${closeParen}${after}`;
     }
   }
 
-  // Return unchanged for other commands
   return command;
 }
 
 /**
- * Enhanced diff function that treats code snapshot as source of truth
- * Database snapshot is used only for comparison to detect what needs migration
+ * Refined diff function with cleaner output and better filtering
  */
 export function diffSnapshots(
   dbSnapshot: Snapshot, // Database state (for comparison)
   codeSnapshot: Snapshot // Code state (source of truth)
 ): DiffResult {
+  console.log("\n[Mongeese] 🔄 Starting diff analysis...");
+  console.log(
+    `   📊 Database snapshot: ${
+      Object.keys(dbSnapshot.collections).length
+    } collections`
+  );
+  console.log(
+    `   💻 Code snapshot: ${
+      Object.keys(codeSnapshot.collections).length
+    } collections`
+  );
+
   const normalizedDb = normalizeSnapshot(dbSnapshot);
   const normalizedCode = normalizeSnapshot(codeSnapshot);
 
   const allUp: MigrationCommand[] = [];
-
   const allDown: MigrationCommand[] = [];
-
   const allWarnings: string[] = [];
 
   const metadata: DiffResult["metadata"] = {
     collections: { added: [], removed: [], modified: [] },
     fields: { added: [], removed: [], modified: [], renamed: [] },
     indexes: { added: [], removed: [], modified: [] },
-    validators: { added: [], removed: [], modified: [] },
+    validators: { added: [], removed: [], modified: [] }, // Keep for compatibility but won't populate
   };
 
-  // Diff collections (code is truth, database is current state)
+  // Diff collections
   const collectionDiff = diffCollections(
     normalizedDb.collections,
     normalizedCode.collections
   );
 
   allUp.push(...collectionDiff.up);
-
   allDown.push(...collectionDiff.down);
-
   allWarnings.push(...collectionDiff.warnings);
 
   // Track collection changes
@@ -1007,55 +699,63 @@ export function diffSnapshots(
     name => !codeCollectionNames.includes(name)
   );
 
-  metadata.collections.modified = codeCollectionNames.filter(name =>
-    dbCollectionNames.includes(name)
-  );
+  // Track collections that actually have changes (not just exist in both)
+  const modifiedCollections: string[] = [];
 
-  // Diff fields for each collection using code-first approach
+  // Diff fields and indexes for each collection using refined approach
   for (const collectionName of codeCollectionNames) {
     const codeCollection = normalizedCode.collections[collectionName];
     const dbCollection = normalizedDb.collections[collectionName];
 
     if (dbCollection) {
-      // Collection exists in both - diff the fields
-      const fieldDiff = diffFieldsCodeFirst(
+      // Collection exists in both - check if there are actual changes
+      let hasFieldChanges = false;
+
+      let hasIndexChanges = false;
+
+      // Diff the fields with refined logic
+      const fieldDiff = diffFieldsRefined(
         collectionName,
         dbCollection.fields, // Database state
         codeCollection.fields // Code state (truth)
       );
 
-      allUp.push(...fieldDiff.up);
-      allDown.push(...fieldDiff.down);
-      allWarnings.push(...fieldDiff.warnings);
+      if (fieldDiff.up.length > 0 || fieldDiff.down.length > 0) {
+        hasFieldChanges = true;
+        allUp.push(...fieldDiff.up);
+        allDown.push(...fieldDiff.down);
+        allWarnings.push(...fieldDiff.warnings);
+      }
+
+      // Diff indexes
+      const indexDiff = diffIndexes(
+        collectionName,
+        dbCollection.indexes || [],
+        codeCollection.indexes || []
+      );
+
+      if (indexDiff.up.length > 0 || indexDiff.down.length > 0) {
+        hasIndexChanges = true;
+        allUp.push(...indexDiff.up);
+        allDown.push(...indexDiff.down);
+        allWarnings.push(...indexDiff.warnings);
+      }
+
+      // Only mark as modified if there are actual changes
+      if (hasFieldChanges || hasIndexChanges) {
+        modifiedCollections.push(collectionName);
+      }
+    } else {
+      // New collection - all fields are new
+      console.log(
+        `   🆕 New collection '${collectionName}' with ${
+          Object.keys(codeCollection.fields).length
+        } fields`
+      );
     }
-
-    // No need to diff indexes or validators, mongoose does this under the hood! 🔥
-
-    //   // Diff indexes
-    //   const indexDiff = diffIndexes(
-    //     collectionName,
-    //     fromCollection.indexes || [],
-    //     toCollection.indexes || []
-    //   );
-
-    //   allUp.push(...indexDiff.up);
-
-    //   allDown.push(...indexDiff.down);
-
-    //   allWarnings.push(...indexDiff.warnings);
-
-    //   // Diff validators
-    //   const validatorDiff = diffValidators(
-    //     collectionName,
-    //     fromCollection.validator,
-    //     toCollection.validator
-    //   );
-
-    //   allUp.push(...validatorDiff.up);
-
-    //   allDown.push(...validatorDiff.down);
-    //   allWarnings.push(...validatorDiff.warnings);
   }
+
+  metadata.collections.modified = modifiedCollections;
 
   // Add session support to all commands
   const up = allUp.map(cmd => ({
@@ -1068,10 +768,19 @@ export function diffSnapshots(
     command: injectSessionIntoCommand(cmd.command),
   }));
 
-  console.log(
-    `[Mongeese] ✅ Diff completed: ${up.length} up migrations, ${down.length} down migrations`
-  );
+  // Filter out non-actionable commands for cleaner output
+  // const actionableUps = up.filter(
+  //   cmd =>
+  //     (!cmd.command.includes("// Schema definition updated") &&
+  //       !cmd.command.startsWith("// TODO: Review type change")) ||
+  //     cmd.safetyLevel === "warning"
+  // );
 
+  // console.log(
+  //   `[Mongeese] ✅ Refined diff completed: ${
+  //     actionableUps.length
+  //   } actionable migrations, ${up.length - actionableUps.length} schema updates`
+  // );
   console.log(`[Mongeese] ⚠️  Generated ${allWarnings.length} warnings`);
 
   return { up, down, warnings: allWarnings, metadata };


### PR DESCRIPTION
#### What does this PR do?

This PR improves the diffing logic by removing mongoose generated fields, simplified the diffing logic by just comparing code  with database and prioritizing code changes over database changes, it cleans up the unnecessary noise when generating migrations and lastly, for migrations, critical operations like `.drop()` and `.dropIndex()`, Mongeese shows you that you need to make those changes outside the migration as they cannot be ran in multi-document transactions, this lets the developer know that they need to either run these operations manually or go to their MongoDB Database and delete manually themselves.


#### Description of Task to be completed?
-

#### How should this be manually tested?
- `npm run build`

#### Any background context you want to provide?
- N/A

#### Screenshots (if appropriate)
- N/A

#### Questions:
- N/A

#### What are the relevant pivotal tracker stories?
- N/A
